### PR TITLE
Add shadow-cljs build

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -37,6 +37,7 @@ import { AtomistWebSdmGoalCreator } from "./lib/goalCreator";
 import {
     JekyllPushTest,
     repoSlugMatches,
+    ShadowCljsPushTest,
     WebPackPushTest,
 } from "./lib/pushTest";
 
@@ -80,6 +81,25 @@ export const configuration = configure<AtomistWebSdmGoals>(async sdm => {
         jekyllDeploy: {
             dependsOn: [goals.tag],
             test: [JekyllPushTest, ToDefaultBranch],
+            goals: [
+                [goals.firebaseStagingDeploy],
+                [goals.fetchStaging, goals.stagingApproval],
+                [goals.releaseTag, goals.firebaseProductionDeploy],
+                [goals.fetchProduction, goals.release, goals.incrementVersion],
+            ],
+        },
+        shadowCljs: {
+            test: [ShadowCljsPushTest],
+            goals: [
+                goals.queue,
+                goals.version,
+                goals.shadowCljs,
+                goals.tag,
+            ],
+        },
+        shadowCljsDeploy: {
+            dependsOn: [goals.tag],
+            test: [ShadowCljsPushTest, ToDefaultBranch],
             goals: [
                 [goals.firebaseStagingDeploy],
                 [goals.fetchStaging, goals.stagingApproval],

--- a/lib/goal.ts
+++ b/lib/goal.ts
@@ -50,6 +50,8 @@ export interface AtomistWebSdmGoals extends DeliveryGoals {
 
     /** Jekyll web site build. */
     jekyll: FulfillableGoal;
+    /** Shadow-cljs web site build. */
+    shadowCljs: FulfillableGoal;
     /** NPM webpack web site build. */
     webpack: FulfillableGoal;
 

--- a/lib/goalCreator.ts
+++ b/lib/goalCreator.ts
@@ -109,6 +109,53 @@ export const AtomistWebSdmGoalCreator: GoalCreator<AtomistWebSdmGoals> = async s
             },
         ],
     });
+    const shadowCljs = container("shadowcljs", {
+        containers: [
+            {
+                args: ["bash", "-c", "npm ci --progress=false && npm run release"],
+                env: [{ name: "NODE_ENV", value: "development" }],
+                image: "shadowcljs-docker:0.0.0-20191206182921",
+                name: "shadowcljs",
+                resources: {
+                    limits: {
+                        cpu: "1000m",
+                        memory: "1024Mi",
+                    },
+                    requests: {
+                        cpu: "100m",
+                        memory: "768Mi",
+                    },
+                },
+                securityContext: {
+                    runAsGroup: 1000,
+                    runAsNonRoot: true,
+                    runAsUser: 1000,
+                },
+            },
+        ],
+        initContainers: [
+            {
+                args: ["/bin/sh", "-c", `chown -Rh 1000:1000 "$ATOMIST_PROJECT_DIR"`],
+                image: "busybox:1.31.1",
+                name: "chown",
+                securityContext: {
+                    runAsGroup: 0,
+                    runAsNonRoot: false,
+                    runAsUser: 0,
+                },
+            },
+        ],
+        output: [
+            {
+                classifier: "node_modules",
+                pattern: { directory: "node_modules" },
+            },
+            {
+                classifier: "site",
+                pattern: { directory: "public" },
+            },
+        ],
+    });
     const codeInspection = new AutoCodeInspection({ isolate: true });
     const htmltest = container("htmltest", {
         containers: [
@@ -160,6 +207,7 @@ export const AtomistWebSdmGoalCreator: GoalCreator<AtomistWebSdmGoals> = async s
         tag,
         releaseTag,
         jekyll,
+        shadowCljs,
         webpack,
         codeInspection,
         htmltest,

--- a/lib/pushTest.ts
+++ b/lib/pushTest.ts
@@ -26,6 +26,11 @@ import {
 export const JekyllPushTest = hasFile("_config.yml");
 
 /**
+ * Test for shadow-cljs configuration file in project.
+ */
+export const ShadowCljsPushTest = hasFile("shadow-cljs.edn");
+
+/**
  * Test for webpack configuration file in project.
  */
 export const WebPackPushTest = hasFile("webpack.config.js");


### PR DESCRIPTION
I've hopefully duplicated the webpack goals into shadow-cljs ones. We're going to need a separate docker image to build on (we need Node and the JVM) and I'm not going to add webpack configuration just yet.