### PR TITLE
Add push test to skip shadow-cljs builds in atomist-skills org

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -452,7 +452,7 @@ export const configuration = configure(async sdm => {
             ],
         },
         shadowCljs: {
-            test: [not(or(repoSlugMatches(/^atomisthq\/admin-app$/),repoSlugMatches(/^atomist-skills/))), ShadowCljsPushTest],
+            test: [not(or(repoSlugMatches(/^atomisthq\/admin-app$/), repoSlugMatches(/^atomist-skills/))), ShadowCljsPushTest],
             goals: [
                 queue,
                 version,

--- a/index.ts
+++ b/index.ts
@@ -25,7 +25,7 @@ import { gcpSupport } from "@atomist/sdm-pack-gcp/lib/gcp";
 import { ImmaterialGoals } from "@atomist/sdm/lib/api/goal/common/Immaterial";
 import { Queue } from "@atomist/sdm/lib/api/goal/common/Queue";
 import { ToDefaultBranch } from "@atomist/sdm/lib/api/mapping/support/commonPushTests";
-import { not } from "@atomist/sdm/lib/api/mapping/support/pushTestUtils";
+import { not, or } from "@atomist/sdm/lib/api/mapping/support/pushTestUtils";
 import { machineOptions } from "./lib/configure";
 import {
     FirebasePushTest,
@@ -452,7 +452,7 @@ export const configuration = configure(async sdm => {
             ],
         },
         shadowCljs: {
-            test: [not(repoSlugMatches(/^atomisthq\/admin-app$/)), ShadowCljsPushTest],
+            test: [not(or(repoSlugMatches(/^atomisthq\/admin-app$/),repoSlugMatches(/^atomist-skills/))), ShadowCljsPushTest],
             goals: [
                 queue,
                 version,

--- a/index.ts
+++ b/index.ts
@@ -455,7 +455,7 @@ export const configuration = configure(async sdm => {
             ],
         },
         shadowCljs: {
-            test: [not(or(repoSlugMatches(/^atomisthq\/admin-app$/), repoSlugMatches(/^atomist-skills/))), ShadowCljsPushTest],
+            test: [not(repoSlugMatches(/^(?:atomist-skills/.*|atomisthq\/admin-app)$/)), ShadowCljsPushTest],
             goals: [
                 queue,
                 version,

--- a/index.ts
+++ b/index.ts
@@ -25,7 +25,10 @@ import { gcpSupport } from "@atomist/sdm-pack-gcp/lib/gcp";
 import { ImmaterialGoals } from "@atomist/sdm/lib/api/goal/common/Immaterial";
 import { Queue } from "@atomist/sdm/lib/api/goal/common/Queue";
 import { ToDefaultBranch } from "@atomist/sdm/lib/api/mapping/support/commonPushTests";
-import { not, or } from "@atomist/sdm/lib/api/mapping/support/pushTestUtils";
+import {
+    not,
+    or,
+} from "@atomist/sdm/lib/api/mapping/support/pushTestUtils";
 import { machineOptions } from "./lib/configure";
 import {
     FirebasePushTest,


### PR DESCRIPTION
shadow-cljs.edn is also used in atomist-skills repos.  I've added this to request that the sdm not schedule goals for Repos containing a shadow-cljs.edn for any repo slug starting with atomist-skills.