### PR TITLE
Enable cancel goal for shadow builds, ignore Changelog commits

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -22,6 +22,7 @@ import { githubGoalStatusSupport } from "@atomist/sdm-core/lib/pack/github-goal-
 import { goalStateSupport } from "@atomist/sdm-core/lib/pack/goal-state/goalState";
 import { k8sGoalSchedulingSupport } from "@atomist/sdm-core/lib/pack/k8s/goalScheduling";
 import { gcpSupport } from "@atomist/sdm-pack-gcp/lib/gcp";
+import {Cancel} from "@atomist/sdm/lib/api/goal/common/Cancel";
 import { ImmaterialGoals } from "@atomist/sdm/lib/api/goal/common/Immaterial";
 import { Queue } from "@atomist/sdm/lib/api/goal/common/Queue";
 import { ToDefaultBranch } from "@atomist/sdm/lib/api/mapping/support/commonPushTests";
@@ -29,6 +30,7 @@ import { not } from "@atomist/sdm/lib/api/mapping/support/pushTestUtils";
 import { machineOptions } from "./lib/configure";
 import {
     FirebasePushTest,
+    IsChangelogCommit,
     IsReleaseCommit,
     JekyllPushTest,
     repoSlugMatches,
@@ -50,6 +52,7 @@ export const configuration = configure(async sdm => {
     );
 
     const queue = new Queue({ concurrent: 5 });
+    const cancel = new Cancel();
     const version = container("version", {
         containers: [
             {
@@ -431,7 +434,7 @@ export const configuration = configure(async sdm => {
 
     return {
         immaterial: {
-            test: [IsReleaseCommit],
+            test: [IsReleaseCommit, IsChangelogCommit],
             goals: ImmaterialGoals.andLock(),
         },
         webStatic: {
@@ -455,6 +458,7 @@ export const configuration = configure(async sdm => {
             test: [not(repoSlugMatches(/^(?:atomist-skills\/.*|atomisthq\/admin-app|atomisthq\/.*-skill)$/)), ShadowCljsPushTest],
             goals: [
                 queue,
+                cancel,
                 version,
                 shadowCljsTest,
                 shadowCljs,

--- a/index.ts
+++ b/index.ts
@@ -22,7 +22,7 @@ import { githubGoalStatusSupport } from "@atomist/sdm-core/lib/pack/github-goal-
 import { goalStateSupport } from "@atomist/sdm-core/lib/pack/goal-state/goalState";
 import { k8sGoalSchedulingSupport } from "@atomist/sdm-core/lib/pack/k8s/goalScheduling";
 import { gcpSupport } from "@atomist/sdm-pack-gcp/lib/gcp";
-import {Cancel} from "@atomist/sdm/lib/api/goal/common/Cancel";
+import { Cancel } from "@atomist/sdm/lib/api/goal/common/Cancel";
 import { ImmaterialGoals } from "@atomist/sdm/lib/api/goal/common/Immaterial";
 import { Queue } from "@atomist/sdm/lib/api/goal/common/Queue";
 import { ToDefaultBranch } from "@atomist/sdm/lib/api/mapping/support/commonPushTests";

--- a/lib/pushTest.ts
+++ b/lib/pushTest.ts
@@ -61,3 +61,12 @@ export const IsReleaseCommit: PushTest = {
         return versionRegexp.test(commitMessage) || changelogRegexp.test(commitMessage);
     },
 };
+
+export const IsChangelogCommit: PushTest = {
+    name: "IsChangelogCommit",
+    mapping: async pi => {
+        const commitMessage = (pi.push.after && pi.push.after.message) ? pi.push.after.message : "";
+        const changelogCommitRegexp = /Changelog:\s\#[\d+]+\sto\s([\w]+[,]?[\s]?)+/;
+        return changelogCommitRegexp.test(commitMessage);
+    },
+};

--- a/test/pushTest.test.ts
+++ b/test/pushTest.test.ts
@@ -15,9 +15,12 @@
  */
 
 import { InMemoryProject } from "@atomist/automation-client/lib/project/mem/InMemoryProject";
-import {StatefulPushListenerInvocation} from "@atomist/sdm/lib/api/dsl/goalContribution";
+import { StatefulPushListenerInvocation } from "@atomist/sdm/lib/api/dsl/goalContribution";
 import * as assert from "power-assert";
-import {FirebasePushTest, IsChangelogCommit} from "../lib/pushTest";
+import {
+    FirebasePushTest,
+    IsChangelogCommit,
+} from "../lib/pushTest";
 
 describe("pushTests", () => {
     describe("FirebaseConfiguration", () => {

--- a/test/pushTest.test.ts
+++ b/test/pushTest.test.ts
@@ -15,8 +15,9 @@
  */
 
 import { InMemoryProject } from "@atomist/automation-client/lib/project/mem/InMemoryProject";
+import {StatefulPushListenerInvocation} from "@atomist/sdm/lib/api/dsl/goalContribution";
 import * as assert from "power-assert";
-import { FirebasePushTest } from "../lib/pushTest";
+import {FirebasePushTest, IsChangelogCommit} from "../lib/pushTest";
 
 describe("pushTests", () => {
     describe("FirebaseConfiguration", () => {
@@ -39,6 +40,41 @@ describe("pushTests", () => {
             const p = InMemoryProject.of({ path: "firebase.prod.json", content: "" });
             const result = await FirebasePushTest.predicate(p);
             assert(result);
+        });
+    });
+    describe("IsChangelogCommit", () => {
+        it("should return true for commits created by changelog that are just pr updates", async () => {
+            const pi: StatefulPushListenerInvocation =  {
+                push: {
+                    after: {
+                        message: "Changelog: #329 to changed",
+                    },
+                },
+            } as any;
+            const result = await IsChangelogCommit.mapping(pi);
+            assert.strictEqual(result, true);
+        });
+        it("should not match release commits", async () => {
+            const pi: StatefulPushListenerInvocation =  {
+                push: {
+                    after: {
+                        message: "Changelog: add release 0.0.1",
+                    },
+                },
+            } as any;
+            const result = await IsChangelogCommit.mapping(pi);
+            assert.strictEqual(result, false);
+        });
+        it("should not match random commit", async () => {
+            const pi: StatefulPushListenerInvocation =  {
+                push: {
+                    after: {
+                        message: "I wish I were a real boy!",
+                    },
+                },
+            } as any;
+            const result = await IsChangelogCommit.mapping(pi);
+            assert.strictEqual(result, false);
         });
     });
 });


### PR DESCRIPTION
- Stop building/deploying for Changelog commits
- For shadow-cljs builds, enable the cancel goal